### PR TITLE
Wait-for-db periodically fails on startup

### DIFF
--- a/app/core/management/commands/wait_for_db.py
+++ b/app/core/management/commands/wait_for_db.py
@@ -10,15 +10,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write('Waiting for database...')
-        db_conn = None
-        while not db_conn:
+        cursor = None
+        while not cursor:
             try:
                 db_conn = connections['default']
                 self.stdout.write('Obtain cursor and verify database...')
-                db_conn.cursor()
+                cursor = db_conn.cursor()
             except OperationalError:
                 self.stdout.write('Database unavailable, waiting 1 second...')
                 time.sleep(1)
-                db_conn = None
 
         self.stdout.write(self.style.SUCCESS('Database available!'))

--- a/app/core/management/commands/wait_for_db.py
+++ b/app/core/management/commands/wait_for_db.py
@@ -14,8 +14,11 @@ class Command(BaseCommand):
         while not db_conn:
             try:
                 db_conn = connections['default']
+                self.stdout.write('Obtain cursor and verify database...')
+                db_conn.cursor()
             except OperationalError:
                 self.stdout.write('Database unavailable, waiting 1 second...')
                 time.sleep(1)
+                db_conn = None
 
         self.stdout.write(self.style.SUCCESS('Database available!'))

--- a/app/core/tests/test_commands.py
+++ b/app/core/tests/test_commands.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from django.core.management import call_command
 from django.db.utils import OperationalError
@@ -9,15 +9,16 @@ class CommandTests(TestCase):
 
     def test_wait_for_db_ready(self):
         """Test waiting for db when db is available"""
-        with patch('django.db.utils.ConnectionHandler.__getitem__') as gi:
-            gi.return_value = True
+        conn = MagicMock(return_value=None)
+        with patch('django.db.utils.ConnectionHandler.__getitem__', return_value=conn):
             call_command('wait_for_db')
-            self.assertEqual(gi.call_count, 1)
+            conn.cursor.assert_called_once()
 
-    @patch('time.sleep', return_value=True)
+    @patch('time.sleep', return_value=None)
     def test_wait_for_db(self, ts):
         """Test waiting for db"""
-        with patch('django.db.utils.ConnectionHandler.__getitem__') as gi:
-            gi.side_effect = [OperationalError] * 5 + [True]
+        conn = MagicMock(return_value=None)
+        with patch('django.db.utils.ConnectionHandler.__getitem__', return_value=conn):
+            conn.cursor.side_effect = [OperationalError] * 5 + [True]
             call_command('wait_for_db')
-            self.assertEqual(gi.call_count, 6)
+            self.assertEqual(conn.cursor.call_count, 6)


### PR DESCRIPTION
Depending upon the timing of the container startup, the `wait-for-db` command may produce false positives, i.e., it will think the database is ready when it is not.  In fact, I think the current implementation of wait-for-db  does not work -- it only gets lucky.  The connection object is lazy and must be *used* in order to produce the `OperationalError` exception.  This PR calls out for a cursor object, which reliably tests that the database is functional.  

Steps to Reproduce:
----------------------
You can reproduce this pretty reliably by repeating the following steps a few times:

```
docker system prune  #<-- remove all stopped containers
docker-compose up
```

`docker system prune` will delete any cached containers (in a stopped state).  In this case, the app container will *sometimes* start *before* the db container, yielding the error below.  Notice in the log trace that the app_1 container is spinning up at the same time as the database and produces a false positive:

```
app_1  | Waiting for database...
app_1  | Database available!
```

Full stack trace for false positive:

```
db_1   | performing post-bootstrap initialization ... sh: locale: not found
db_1   | 2022-02-08 13:28:26.326 UTC [30] WARNING:  no usable system locales were found
db_1   | ok
app_1  | Waiting for database...
app_1  | Database available!
db_1   | syncing data to disk ...
db_1   | WARNING: enabling "trust" authentication for local connections
db_1   | You can change this by editing pg_hba.conf or using the option -A, or
db_1   | --auth-local and --auth-host, the next time you run initdb.
db_1   | ok
db_1   |
db_1   | Success. You can now start the database server using:
db_1   |
db_1   |     pg_ctl -D /var/lib/postgresql/data -l logfile start
db_1   |
db_1   | waiting for server to start....2022-02-08 13:28:27.202 UTC [36] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db_1   | 2022-02-08 13:28:27.215 UTC [37] LOG:  database system was shut down at 2022-02-08 13:28:26 UTC
db_1   | 2022-02-08 13:28:27.219 UTC [36] LOG:  database system is ready to accept connections
db_1   |  done
db_1   | server started
app_1  | Traceback (most recent call last):
app_1  |   File "/usr/local/lib/python3.7/site-packages/django/db/backends/base/base.py", line 216, in ensure_connection
app_1  |     self.connect()
app_1  |   File "/usr/local/lib/python3.7/site-packages/django/db/backends/base/base.py", line 194, in connect
app_1  |     self.connection = self.get_new_connection(conn_params)
app_1  |   File "/usr/local/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
app_1  |     connection = Database.connect(**conn_params)
app_1  |   File "/usr/local/lib/python3.7/site-packages/psycopg2/__init__.py", line 130, in connect
app_1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
app_1  | psycopg2.OperationalError: connection to server at "db" (172.24.0.2), port 5432 failed: Connection refused
app_1  | 	Is the server running on that host and accepting TCP/IP connections?
```